### PR TITLE
Not found fields should have the `None` value, not `{}`

### DIFF
--- a/snooze/utils/modification.py
+++ b/snooze/utils/modification.py
@@ -85,7 +85,7 @@ class RegexParse(Modification):
             key, regex = resolve(record, self.args)
             results = re.search(regex, record[key])
             if results:
-                for name, value in results.groupdict({}).items():
+                for name, value in results.groupdict().items():
                     record[name] = value
                 return True
             return False

--- a/tests/utils/test_modification.py
+++ b/tests/utils/test_modification.py
@@ -54,6 +54,16 @@ def test_modification_regex_parse():
     assert return_code
     assert record == {'message': 'Error during cronjob', 'appname': 'CRON', 'pid': '12345'}
 
+def test_modification_regex_parse_conditional():
+    record = {'hostname': 'myenv-myrole01'}
+    modification = get_modification('REGEX_PARSE', 'hostname', '((?P<company>[a-z]+)-)?(?P<environment>[a-z]+)-(?P<role>[a-z]+)(?P<nodenumber>\d+)')
+    return_code = modification.modify(record)
+    assert return_code
+    assert record['environment'] == 'myenv'
+    assert record['role'] == 'myrole'
+    assert record['nodenumber'] == '01'
+    assert record['company'] == None
+
 def test_modification_regex_parse_broken_regex():
     record = {'message': 'CRON[12345]: Error during cronjob'}
     modification = get_modification('REGEX_PARSE', 'message', '(?P<appname.*?)\[(?P<pid>\d+)\]: (?P<message>.*)')


### PR DESCRIPTION
There was a misunderstanding in how the `default` argument was interpreted. It is not the default for
the whole groupdict object, but the default for one field that was not found.

As per documentation:
```
match.groupdict(default=None)
    Return a dictionary containing all the named subgroups of the match, keyed by the subgroup name. The
    default argument is used for groups that did not participate in the match; it defaults to None.
```